### PR TITLE
Undefined names: import signal, time

### DIFF
--- a/dlinject.py
+++ b/dlinject.py
@@ -14,10 +14,13 @@ BANNER = r"""
 source: https://github.com/DavidBuchanan314/dlinject
 """
 
-import os
-import sys
-import re
 import argparse
+import os
+import re
+import signal
+import sys
+import time
+
 from elftools.elf.elffile import ELFFile
 from pwn import asm, log, context
 context.arch = "amd64"


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/DavidBuchanan314/dlinject on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./dlinject.py:63:16: F821 undefined name 'signal'
		os.kill(pid, signal.SIGSTOP)
               ^
./dlinject.py:70:4: F821 undefined name 'time'
			time.sleep(0.1)
   ^
./dlinject.py:83:4: F821 undefined name 'time'
			time.sleep(0.1)
   ^
./dlinject.py:274:16: F821 undefined name 'signal'
		os.kill(pid, signal.SIGCONT)
               ^
4     F821 undefined name 'signal'
4
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.